### PR TITLE
viewファイルやデータを日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,3 +47,6 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+# Japanese
+ gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.6)
       actionpack (= 6.0.6)
       activesupport (= 6.0.6)
@@ -201,6 +204,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.7)
+  rails-i18n
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -22,14 +22,21 @@ class ArticlesController < ApplicationController
 
   #POST/articles
   def create
+    @article = Article.new(article_params)
+    if @article.save
+      redirect_to @article, notice: "#{t('activerecord.models.article')}を作成しました。"
 
+    else
+      render :new, status: :unprocessable_entity
+    end
   end
 
   #PATCH/articles/1
   def update
     @article = Article.find(params[:id])
     if @article.update(article_params)
-     redirect_to @article, notice: "Article was successfully updated."
+     redirect_to @article, notice: "#{t('activerecord.models.article')}を編集しました。"
+
     else
       render :edit, status: :unprocessable_entity
     end
@@ -37,6 +44,8 @@ class ArticlesController < ApplicationController
 
   #DELETE/articles/1
   def destroy
+    @article = Article.find(params[:id])
+    redirect_to articles_url, notice:  "#{t('activerecord.models.article')}を削除しました。"
   end
 
   private

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,5 +1,5 @@
-<h1>Editing Article</h1>
+<h1>記事編集</h1>
 
 <%= render 'form', article: @article %>
-<%= link_to 'Show', @article %>
-<%= link_to 'Back', articles_path %>
+<%= link_to '詳細', @article %>
+<%= link_to '一覧', articles_path %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,12 +1,12 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Articles</h1>
+<h1>記事</h1>
 
 <table>
   <thead>
     <tr>
-      <th>Title</th>
-      <th>Content</th>
+      <th>タイトル</th>
+      <th>本文</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -16,8 +16,9 @@
       <tr>
         <td><%= article.title %></td>
         <td><%= article.content %></td>
-        <td><%= link_to 'Show', article %></td>
-        <td><%= link_to 'Edit', edit_article_path(article) %>
+        <td><%= link_to '詳細', article %></td>
+        <td><%= link_to '編集', edit_article_path(article) %>
+        <td><%= link_to '削除', article, method: :delete, data: { confirm: 'Are you sure?' } %></td>
       </td>
       </tr>
     <% end %>
@@ -26,4 +27,4 @@
 
 <br>
 
-<%= link_to 'New Article', new_article_path %>
+<%= link_to "記事作成", new_article_path %>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,5 +1,5 @@
-<h1>New Article</h1>
+<h1>記事作成</h1>
 
 <%= render 'form', article: @article %>
 
-<%= link_to 'Back', articles_path %>
+<%= link_to '一覧', articles_path %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -1,14 +1,14 @@
 <p id="notice"><%= notice %></p>
 
 <p>
-  <strong>Title:</strong>
+  <strong>タイトル:</strong>
   <%= @article.title %>
 </p>
 
 <p>
-  <strong>Content:</strong>
+  <strong>本文:</strong>
   <%= @article.content %>
 </p>
 
-<%= link_to 'Edit', edit_article_path(@article) %> |
-<%= link_to 'Back', articles_path %>
+<%= link_to '編集', edit_article_path(@article) %> |
+<%= link_to '一覧', articles_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,8 @@ module WonderfulPostApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.i18n.default_locale = :ja
+    config.time_zone = "Asia/Tokyo"
 
     config.generators do |g|
       g.jbuilder false

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,13 @@
+# ↓「日本語」ということを宣言
+ja:
+  # ↓activerecord関連(つまりDBに関連)する項目ということを宣言
+  activerecord:
+    # ↓model名(つまりテーブル名)を宣言
+    models:
+      article: 記事
+
+    # ↓modelのattribute名(つまりテーブル名のカラム名)を宣言
+    attributes:
+      article:
+        title: タイトル
+        content: 本文


### PR DESCRIPTION
## 概要
- Gemfile に `gem rails-i18n`を導入後、`bundle install`
- config/locales/ja.yml を新規作成。
  -テーブル名やカラム名が日本語になるように追記
- application.rb に`config.i18n.default_locale = :ja``config.time_zone = "Asia/Tokyo"`を追記
- viewファイルの内容も手動で日本語に編集　