### PR TITLE
UserテーブルとArticleテーブルの紐付けを行う

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,4 +51,7 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # Japanese
- gem 'rails-i18n'
+gem 'rails-i18n'
+
+# devise_jabapanese
+gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.10.2)
+      devise (>= 4.8.0)
     erubi (1.11.0)
     ffi (1.15.5)
     globalid (1.0.0)
@@ -210,6 +212,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   devise
+  devise-i18n
   jbuilder (~> 2.7)
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,6 @@
 class Article < ApplicationRecord
   validates :title, presence: true
   validates :content, presence: true
+
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :articles
 end

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,0 +1,21 @@
+<nav class="navbar navbar-expand-sm navbar-light bg-light">
+  <div class="container-fluid">
+     <%= link_to "TOP", root_path, class: "navbar-brand" %>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <%if user_signed_in?%>
+          <li class="nav-item">
+            <%= link_to "ログアウト", destroy_user_session_path, method: :delete, class: "nav-link active" %>
+          </li>
+        <% else %>
+          <li class="nav-item">
+            <%= link_to "サインイン", new_user_registration_path, class: "nav-link active" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "ログイン", new_user_session_path, class: "nav-link active" %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
   </head>
 
   <body>
+    <%= render partial: "layouts/navbar" %>
     <div class="container">
     <%= yield %>
     </div>

--- a/db/migrate/20220928104941_add_user_id_to_articles.rb
+++ b/db/migrate/20220928104941_add_user_id_to_articles.rb
@@ -1,0 +1,5 @@
+class AddUserIdToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :articles, :user,  foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_28_061633) do
+ActiveRecord::Schema.define(version: 2022_09_28_104941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,8 @@ ActiveRecord::Schema.define(version: 2022_09_28_061633) do
     t.text "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_articles_on_user_id"
   end
 
   create_table "sample_articles", force: :cascade do |t|
@@ -41,4 +43,5 @@ ActiveRecord::Schema.define(version: 2022_09_28_061633) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "articles", "users"
 end


### PR DESCRIPTION
## 概要
- `bundle exec rails g migration AddUserIdToArticles user:references` を実行
  - `bundle exec rails db:migrate` でDBに反映
- userモデルに`has_many :articles` を追加
- articleモデルに`belongs_to :user` を追加